### PR TITLE
Add class-specific icons to Java files in file tree

### DIFF
--- a/src/lib/components/command.svelte
+++ b/src/lib/components/command.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { CommandDialog, CommandGroup, CommandInput, CommandItem, CommandList } from "$lib/components/ui/command";
     import { onMount } from "svelte";
-    import { type Entry } from "$lib/workspace";
+    import type { Entry } from "$lib/workspace";
     import { entryIcon } from "$lib/components/icons";
     import { Search } from "@lucide/svelte";
     import { cn } from "$lib/components/utils";

--- a/src/lib/components/crumb/crumb.svelte
+++ b/src/lib/components/crumb/crumb.svelte
@@ -18,11 +18,9 @@
     import { cn } from "$lib/components/utils";
     import { isEncodingDependent, type Tab } from "$lib/tab";
     import type { Encoding } from "$lib/workspace/encoding";
-    import { entries as allEntries } from "$lib/workspace";
     import { entryIcon } from "$lib/components/icons";
     import type { Task } from "$lib/task";
     import Tasks from "./tasks.svelte";
-    import { derived, get } from "svelte/store";
 
     interface Props {
         tab: Tab | null;
@@ -31,7 +29,6 @@
     }
 
     let { tab, tasks, encoding }: Props = $props();
-    const entries = $derived(get(allEntries));
 </script>
 
 <Separator />

--- a/src/lib/components/icons/index.ts
+++ b/src/lib/components/icons/index.ts
@@ -26,7 +26,7 @@ import {
     TextQuote,
 } from "@lucide/svelte";
 import type { UTF8Entry } from "@run-slicer/asm/pool";
-import { Modifier } from "@run-slicer/asm/spec/modifier";
+import { Modifier } from "@run-slicer/asm/spec";
 import type { Component } from "svelte";
 import Android from "./android.svelte";
 import GitHub from "./github.svelte";
@@ -59,6 +59,17 @@ export const tabIcon = (tabType: TabType, entry: Entry): StyledIcon => {
 
     return entryIcon(entry);
 };
+
+const parseClassModifiers = (modifiers: number) => ({
+    isPublic: (modifiers & Modifier.PUBLIC) !== 0,
+    isFinal: (modifiers & Modifier.FINAL) !== 0,
+    isSuper: (modifiers & Modifier.SUPER) !== 0,
+    isInterface: (modifiers & Modifier.INTERFACE) !== 0,
+    isAbstract: (modifiers & Modifier.ABSTRACT) !== 0,
+    isSynthetic: (modifiers & Modifier.SYNTHETIC) !== 0,
+    isAnnotation: (modifiers & Modifier.ANNOTATION) !== 0,
+    isEnum: (modifiers & Modifier.ENUM) !== 0,
+});
 
 export const entryIcon = (entry: Entry): StyledIcon => {
     switch (entry.type) {
@@ -96,19 +107,6 @@ export const entryIcon = (entry: Entry): StyledIcon => {
 
     return fileIcon(entry.name);
 };
-
-function parseClassModifiers(modifiers: number) {
-    return {
-        isPublic: (modifiers & Modifier.PUBLIC) !== 0,
-        isFinal: (modifiers & Modifier.FINAL) !== 0,
-        isSuper: (modifiers & Modifier.SUPER) !== 0,
-        isInterface: (modifiers & Modifier.INTERFACE) !== 0,
-        isAbstract: (modifiers & Modifier.ABSTRACT) !== 0,
-        isSynthetic: (modifiers & Modifier.SYNTHETIC) !== 0,
-        isAnnotation: (modifiers & Modifier.ANNOTATION) !== 0,
-        isEnum: (modifiers & Modifier.ENUM) !== 0,
-    };
-}
 
 export const fileIcon = (label: string): StyledIcon => {
     const dotIndex = label.lastIndexOf(".");
@@ -179,4 +177,4 @@ export const paneIcon = (pos: TabPosition, open: boolean): Icon => {
     }
 };
 
-export { Android, GitHub, Kotlin };
+export { Abstract, Android, Annotation, Class, Enum, GitHub, Interface, Kotlin, Record };

--- a/src/lib/components/icons/java/abstract.svelte
+++ b/src/lib/components/icons/java/abstract.svelte
@@ -14,4 +14,4 @@
     ] as IconNode;
 </script>
 
-<Icon name="record" {...props} {strokeWidth} {iconNode} />
+<Icon name="abstract" {...props} {strokeWidth} {iconNode} />

--- a/src/lib/components/icons/java/annotation.svelte
+++ b/src/lib/components/icons/java/annotation.svelte
@@ -14,4 +14,4 @@
     ] as IconNode;
 </script>
 
-<Icon name="record" {...props} {strokeWidth} {iconNode} />
+<Icon name="annotation" {...props} {strokeWidth} {iconNode} />

--- a/src/lib/components/icons/java/class.svelte
+++ b/src/lib/components/icons/java/class.svelte
@@ -14,4 +14,4 @@
     ] as IconNode;
 </script>
 
-<Icon name="record" {...props} {strokeWidth} {iconNode} />
+<Icon name="class" {...props} {strokeWidth} {iconNode} />

--- a/src/lib/components/icons/java/enum.svelte
+++ b/src/lib/components/icons/java/enum.svelte
@@ -14,4 +14,4 @@
     ] as IconNode;
 </script>
 
-<Icon name="record" {...props} {strokeWidth} {iconNode} />
+<Icon name="enum" {...props} {strokeWidth} {iconNode} />

--- a/src/lib/components/icons/java/interface.svelte
+++ b/src/lib/components/icons/java/interface.svelte
@@ -14,4 +14,4 @@
     ] as IconNode;
 </script>
 
-<Icon name="record" {...props} {strokeWidth} {iconNode} />
+<Icon name="interface" {...props} {strokeWidth} {iconNode} />

--- a/src/lib/components/pane/tree/node.svelte
+++ b/src/lib/components/pane/tree/node.svelte
@@ -1,5 +1,5 @@
 <script lang="ts" module>
-    import { type Entry } from "$lib/workspace";
+    import type { Entry } from "$lib/workspace";
 
     export interface Node {
         label: string;
@@ -15,16 +15,15 @@
     import TreeNode from "./node.svelte";
     import { ChevronDown, ChevronRight, Folder } from "@lucide/svelte";
     import { cn } from "$lib/components/utils";
-    import { entryIcon } from "$lib/components/icons";
+    import { entryIcon, fileIcon } from "$lib/components/icons";
 
     interface Props extends HTMLAttributes<HTMLDivElement> {
-        entries: Entry[];
         data: Node;
         onopen?: (data: Node) => void;
         onmenu?: (e: MouseEvent, data: Node) => void;
     }
 
-    let { data = $bindable(), entries, onopen, onmenu, ...rest }: Props = $props();
+    let { data = $bindable(), onopen, onmenu, ...rest }: Props = $props();
     $effect(() => {
         // no children and not a leaf node, remove ourselves from the parent
         if (data.parent && !data.nodes && !data.entry) {
@@ -32,7 +31,7 @@
         }
     });
 
-    const iconData = $derived(data.entry ? entryIcon(data.entry) : undefined);
+    const { icon: FileIcon, classes } = $derived(data.entry ? entryIcon(data.entry) : fileIcon(data.label));
 
     let expanded = $state(data.expanded === undefined ? (data.parent?.nodes?.length || 0) === 1 : data.expanded);
     $effect(() => {
@@ -55,8 +54,8 @@
         {@const ExpandedIcon = expanded ? ChevronDown : ChevronRight}
         <button class="highlight flex w-full py-[0.2rem]" onclick={() => (expanded = !expanded)}>
             <ExpandedIcon size={14} class="text-muted-foreground my-auto mr-1 min-w-[14px]" />
-            {#if iconData}
-                <iconData.icon size={16} class={cn("my-auto mr-1 min-w-[16px]", iconData.classes)} />
+            {#if data.entry}
+                <FileIcon size={16} class={cn("my-auto mr-1 min-w-[16px]", classes)} />
             {:else}
                 <Folder size={16} class="fill-muted my-auto mr-1 min-w-[16px]" />
             {/if}
@@ -74,9 +73,7 @@
         {/if}
     {:else}
         <button class="highlight flex w-full py-[0.2rem]" ondblclick={() => onopen?.(data)}>
-            {#if iconData}
-                <iconData.icon size={16} class={cn("my-auto mr-1 min-w-[16px]", iconData.classes)} />
-            {/if}
+            <FileIcon size={16} class={cn("my-auto mr-1 min-w-[16px]", classes)} />
             <span class="text-sm">{data.label}</span>
         </button>
     {/if}

--- a/src/lib/components/pane/tree/tree.svelte
+++ b/src/lib/components/pane/tree/tree.svelte
@@ -17,7 +17,7 @@
             while (child.nodes?.length === 1 && !child.entry && !child.nodes[0].entry) {
                 // collapse label
                 const next = child.nodes[0];
-                child.label += "." + next.label;
+                child.label += "/" + next.label;
                 child.nodes = next.nodes;
             }
 

--- a/src/lib/tab.ts
+++ b/src/lib/tab.ts
@@ -6,7 +6,6 @@ import { AnalysisState } from "$lib/workspace/analysis";
 import { unwrapTransform } from "$lib/workspace/data";
 import { Box, Folders, ScrollText, Search, Sparkles } from "@lucide/svelte";
 import { derived, get, writable } from "svelte/store";
-import { entries } from "./workspace/index";
 
 export enum TabType {
     PROJECT = "project",


### PR DESCRIPTION
This PR enhances the file tree by displaying custom icons for Java files based on their respective class types (e.g., class, interface, enum, annotation, record, abstract class). This improves visual clarity and makes it easier to navigate decompiled Java projects in the decompiler.