### PR TITLE
feat: add "Open from URL" dialog for external file loading

### DIFF
--- a/src/lib/components/dialog/index.ts
+++ b/src/lib/components/dialog/index.ts
@@ -5,6 +5,7 @@ import ScriptDialog from "./script.svelte";
 import ScriptDeleteDialog from "./script_delete.svelte";
 import ScriptLoadDialog from "./script_load.svelte";
 import ScriptLoadShareDialog from "./script_load_share.svelte";
+import LoadExternal from './load_external.svelte'
 
 export {
     AboutDialog,
@@ -14,4 +15,5 @@ export {
     ScriptDialog,
     ScriptLoadDialog,
     ScriptLoadShareDialog,
+    LoadExternal
 };

--- a/src/lib/components/dialog/load_external.svelte
+++ b/src/lib/components/dialog/load_external.svelte
@@ -1,0 +1,63 @@
+<script lang="ts">
+    import {
+        Dialog,
+        DialogContent,
+        DialogDescription,
+        DialogFooter,
+        DialogHeader,
+        DialogTitle,
+    } from "$lib/components/ui/dialog";
+    import { Label } from "$lib/components/ui/label";
+    import { Input } from "$lib/components/ui/input";
+    import { Button } from "$lib/components/ui/button";
+    import { cn } from "$lib/components/utils";
+    import { loadExternally } from "$lib/workspace";
+    import type { ModalProps } from "svelte-modals";
+
+    let { isOpen, close }: ModalProps = $props();
+
+    let value = $state("");
+    let invalid = $state(false);
+    const loadFile = async () => {
+        const value0 = value.trim();
+        if (!value0) {
+            invalid = true;
+            return;
+        }
+
+        isOpen = false;
+        loadExternally(value0)
+    };
+</script>
+
+<Dialog bind:open={isOpen} onOpenChangeComplete={(open) => open || close()}>
+    <DialogContent>
+        <DialogHeader>
+            <DialogTitle>Open File Externally</DialogTitle>
+            <DialogDescription>
+                Import a file from an arbitrary URL here.
+            </DialogDescription>
+        </DialogHeader>
+        <div class="grid grid-cols-6 items-center gap-4">
+            <Label for="name" class="text-right">
+                URL
+            </Label>
+            <Input
+                id="name"
+                placeholder="https://..."
+                class={cn(
+                    "col-span-5",
+                    !invalid ||
+                        "border-destructive ring-offset-destructive"
+                )}
+                bind:value
+                onchange={() => (invalid = false)}
+            />
+        </div>
+        <DialogFooter>
+            <Button type="submit" onclick={loadFile}>
+                Import
+            </Button>
+        </DialogFooter>
+    </DialogContent>
+</Dialog>

--- a/src/lib/components/menu/menu.svelte
+++ b/src/lib/components/menu/menu.svelte
@@ -9,7 +9,7 @@
     import { Modifier } from "$lib/shortcut";
     import Shortcut from "./shortcut.svelte";
     import ScriptMenu from "./script/menu.svelte";
-    import { AboutDialog, ClearDialog, ScriptLoadDialog } from "$lib/components/dialog";
+    import { AboutDialog, ClearDialog, LoadExternal, ScriptLoadDialog } from "$lib/components/dialog";
     import {
         Menubar,
         MenubarCheckboxItem,
@@ -30,6 +30,7 @@
         Clipboard,
         Code,
         Coffee,
+        ExternalLink,
         FileCode2,
         GitBranchPlus,
         Globe,
@@ -180,6 +181,12 @@
                 </MenubarItem>
                 <MenubarItem onclick={() => handler.add()}>
                     Add <Shortcut key="o" modifier={Modifier.CTRL | Modifier.SHIFT} />
+                </MenubarItem>
+                <MenubarItem onclick={() => modals.open(LoadExternal)} class="justify-between">
+                    Open from URL <ExternalLink
+                    class="text-muted-foreground"
+                    size={16}
+                />
                 </MenubarItem>
                 <MenubarItem disabled={entries.length === 0} onclick={() => modals.open(ClearDialog, { handler })}>
                     Clear all


### PR DESCRIPTION
Slicer already supported loading files from external URLs using the `?url=` parameter, but this feature was relatively hidden and not very discoverable for most users. This PR introduces a dedicated "Open from URL" dialog to make this functionality more visible and user-friendly.

- Adds a new dialog accessible from the main UI to open files via URL

- Improves UX by removing the need to manually edit the query string

- Keeps support for the existing ?url= param for backward compatibility

This should make it easier for users to quickly open remote files without relying on URL manipulation.