### PR TITLE
feat: add context menu to Pane headers for closing actions

### DIFF
--- a/src/lib/components/menu_label.svelte
+++ b/src/lib/components/menu_label.svelte
@@ -4,19 +4,12 @@
 
     interface Props {
         inset?: boolean;
-        center?: boolean;
         children?: Snippet;
     }
 
-    let { inset, center, children }: Props = $props();
+    let { inset, children }: Props = $props();
 </script>
 
-<div
-    class={cn(
-        "text-foreground overflow-hidden px-2 py-1.5 text-sm font-semibold text-ellipsis",
-        center && "text-center",
-        inset && "pl-8"
-    )}
->
+<div class={cn("text-foreground overflow-hidden px-2 py-1.5 text-sm font-semibold text-ellipsis", inset && "pl-8")}>
     {@render children?.()}
 </div>

--- a/src/lib/components/pane/header/item.svelte
+++ b/src/lib/components/pane/header/item.svelte
@@ -6,9 +6,16 @@
     import { X } from "@lucide/svelte";
     import type { StyledIcon } from "$lib/components/icons";
     import { cn } from "$lib/components/utils";
-    import { ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem } from "$lib/components/ui/context-menu";
+    import {
+        ContextMenu,
+        ContextMenuTrigger,
+        ContextMenuContent,
+        ContextMenuItem,
+        ContextMenuSeparator,
+    } from "$lib/components/ui/context-menu";
     import { Modifier } from "$lib/shortcut";
     import Shortcut from "$lib/components/menu/shortcut.svelte";
+    import ContextMenuLabel from "$lib/components/menu_label.svelte";
 
     interface Props {
         name?: string;
@@ -65,18 +72,14 @@
             {/if}
         </button>
     </ContextMenuTrigger>
-    <ContextMenuContent>
+    <ContextMenuContent class="w-48">
+        <ContextMenuLabel>{name}</ContextMenuLabel>
+        <ContextMenuSeparator />
         <ContextMenuItem onclick={(e) => handleClose(e, "self")} class="justify-between">
-            Close <Shortcut key="w" modifier={Modifier.CTRL | Modifier.ALT} />
+            Close {#if active}<Shortcut key="w" modifier={Modifier.CTRL | Modifier.ALT} />{/if}
         </ContextMenuItem>
-        <ContextMenuItem onclick={(e) => handleClose(e, "others")}>
-            Close Others
-        </ContextMenuItem>
-        <ContextMenuItem onclick={(e) => handleClose(e, "right")}>
-            Close to the Right
-        </ContextMenuItem>
-        <ContextMenuItem onclick={(e) => handleClose(e, "all")}>
-            Close All
-        </ContextMenuItem>
+        <ContextMenuItem onclick={(e) => handleClose(e, "others")}>Close others</ContextMenuItem>
+        <ContextMenuItem onclick={(e) => handleClose(e, "right")}>Close to the right</ContextMenuItem>
+        <ContextMenuItem onclick={(e) => handleClose(e, "all")}>Close all</ContextMenuItem>
     </ContextMenuContent>
 </ContextMenu>

--- a/src/lib/components/pane/header/item.svelte
+++ b/src/lib/components/pane/header/item.svelte
@@ -1,7 +1,14 @@
+<script lang="ts" module>
+    export type CloseType = "self" | "others" | "right" | "all";
+</script>
+
 <script lang="ts">
     import { X } from "@lucide/svelte";
     import type { StyledIcon } from "$lib/components/icons";
     import { cn } from "$lib/components/utils";
+    import { ContextMenu, ContextMenuTrigger, ContextMenuContent, ContextMenuItem } from "$lib/components/ui/context-menu";
+    import { Modifier } from "$lib/shortcut";
+    import Shortcut from "$lib/components/menu/shortcut.svelte";
 
     interface Props {
         name?: string;
@@ -9,16 +16,16 @@
         active?: boolean;
         closeable?: boolean;
         onclick?: () => void;
-        onclose?: () => void;
+        onclose?: (type: CloseType) => void;
     }
 
     let { name = "", icon = null, active = true, closeable = false, onclick, onclose }: Props = $props();
 
     let Icon = $derived(icon?.icon);
 
-    const handleClose = (e: MouseEvent | KeyboardEvent) => {
+    const handleClose = (e: MouseEvent | KeyboardEvent, type: CloseType) => {
         e.stopPropagation();
-        onclose?.();
+        onclose?.(type);
     };
 
     let elem: HTMLButtonElement | undefined = $state();
@@ -29,29 +36,47 @@
     });
 </script>
 
-<button
-    bind:this={elem}
-    class={cn(
-        "inline-flex h-full max-w-96 cursor-default items-center px-3",
-        !active || "border-t-primary bg-background border-t"
-    )}
-    aria-label={name}
-    {onclick}
->
-    {#if icon}
-        <Icon size={16} class={cn("mr-1.5 min-w-[16px]", icon.classes)} />
-    {/if}
-    <span class="overflow-hidden text-sm break-keep text-ellipsis whitespace-nowrap">{name}</span>
-    {#if closeable}
-        <div
-            role="button"
-            tabindex="-1"
-            class="ml-3 cursor-pointer"
-            aria-label="Close"
-            onclick={handleClose}
-            onkeydown={handleClose}
+<ContextMenu>
+    <ContextMenuTrigger>
+        <button
+            bind:this={elem}
+            class={cn(
+                "inline-flex h-full max-w-96 cursor-default items-center px-3",
+                !active || "border-t-primary bg-background border-t"
+            )}
+            aria-label={name}
+            {onclick}
         >
-            <X size={14} class="text-muted-foreground/60 hover:text-muted-foreground/80 min-w-[14px]" />
-        </div>
-    {/if}
-</button>
+            {#if icon}
+                <Icon size={16} class={cn("mr-1.5 min-w-[16px]", icon.classes)} />
+            {/if}
+            <span class="overflow-hidden text-sm break-keep text-ellipsis whitespace-nowrap">{name}</span>
+            {#if closeable}
+                <div
+                    role="button"
+                    tabindex="-1"
+                    class="ml-3 cursor-pointer"
+                    aria-label="Close"
+                    onclick={(e) => handleClose(e, "self")}
+                    onkeydown={(e) => handleClose(e, "self")}
+                >
+                    <X size={14} class="text-muted-foreground/60 hover:text-muted-foreground/80 min-w-[14px]" />
+                </div>
+            {/if}
+        </button>
+    </ContextMenuTrigger>
+    <ContextMenuContent>
+        <ContextMenuItem onclick={(e) => handleClose(e, "self")} class="justify-between">
+            Close <Shortcut key="w" modifier={Modifier.CTRL | Modifier.ALT} />
+        </ContextMenuItem>
+        <ContextMenuItem onclick={(e) => handleClose(e, "others")}>
+            Close Others
+        </ContextMenuItem>
+        <ContextMenuItem onclick={(e) => handleClose(e, "right")}>
+            Close to the Right
+        </ContextMenuItem>
+        <ContextMenuItem onclick={(e) => handleClose(e, "all")}>
+            Close All
+        </ContextMenuItem>
+    </ContextMenuContent>
+</ContextMenu>

--- a/src/lib/components/pane/pane.svelte
+++ b/src/lib/components/pane/pane.svelte
@@ -68,14 +68,16 @@
         if (!tabs) return;
 
         const samePosition = (t: Tab) => t.position === tab.position;
-        const tabIndex = tabs.indexOf(tab);
-
         const filteredTabs = tabs.filter(samePosition);
+
+        const localIndex = filteredTabs.findIndex((t) => t.id === tab.id);
+
+        const isLast = localIndex === filteredTabs.length - 1;
 
         const targets = {
             self: [tab],
             others: filteredTabs.filter((t) => t.id !== tab.id),
-            right: filteredTabs.slice(tabIndex - 1),
+            right: isLast || localIndex === -1 ? [] : filteredTabs.slice(localIndex + 1),
             all: filteredTabs,
         } as const;
 

--- a/src/lib/components/pane/pane.svelte
+++ b/src/lib/components/pane/pane.svelte
@@ -11,6 +11,7 @@
     import { Plus } from "@lucide/svelte";
     import { paneIcon } from "$lib/components/icons";
     import type { PaneAPI } from "paneforge";
+    import type { CloseType } from "./header/item.svelte";
 
     interface Props {
         tabs: Tab[];
@@ -62,6 +63,26 @@
             pane.expand();
         }
     });
+
+    const handleClose = (type: CloseType, tab: Tab) => {
+        if (!tabs) return;
+
+        const samePosition = (t: Tab) => t.position === tab.position;
+        const tabIndex = tabs.indexOf(tab);
+
+        const filteredTabs = tabs.filter(samePosition);
+
+        const targets = {
+            self: [tab],
+            others: filteredTabs.filter((t) => t.id !== tab.id),
+            right: filteredTabs.slice(tabIndex - 1),
+            all: filteredTabs,
+        } as const;
+
+        const toClose = targets[type] ?? [];
+
+        toClose.forEach(handler.close);
+    };
 </script>
 
 {#if handleBefore}<ResizableHandle class={cn(hidden && "hidden")} />{/if}
@@ -86,7 +107,7 @@
                         icon={tab0.icon}
                         closeable={tab0.closeable}
                         onclick={() => updateCurrent(position, tab0)}
-                        onclose={() => handler.close(tab0)}
+                        onclose={(type) => handleClose(type, tab0)}
                     />
                 {/each}
             </div>

--- a/src/lib/components/pane/tree/menu.svelte
+++ b/src/lib/components/pane/tree/menu.svelte
@@ -38,8 +38,8 @@
     let entry = $derived(node.entry);
 </script>
 
-<ContextMenuContent class="max-w-[16rem] min-w-48">
-    <ContextMenuLabel center>{node.label}</ContextMenuLabel>
+<ContextMenuContent class="w-48">
+    <ContextMenuLabel>{node.label}</ContextMenuLabel>
     <ContextMenuSeparator />
     {#if entry}
         <ContextMenuSub>


### PR DESCRIPTION
This PR adds a context menu to each PaneHeaderItem, allowing users to quickly manage open panes with common closing actions:

- Close the current pane [with the shortcut indicator]
- Close Others to keep only the selected pane open
- Close to the Right for quick workspace cleanup
- Close All to reset the layout

This improves UX by giving users more direct control over their open panes, similar to behavior found in modern IDEs and editors.

Preview:
<img width="379" height="194" alt="image" src="https://github.com/user-attachments/assets/46d38108-c5c9-4e86-9808-3a51f2f31dce" />
