### PR TITLE
feat: add notification support to scripting API

### DIFF
--- a/script/index.d.ts
+++ b/script/index.d.ts
@@ -623,6 +623,51 @@ export interface I18NContext {
 }
 
 /**
+ * Options for configuring a toast notification.
+ */
+export interface NotificationOptions {
+    /**
+     * Translation key for the description of this notification.
+     */
+    readonly description?: string;
+
+    /**
+     * Translation arguments for the description of this notification.
+     */
+    readonly descriptionArgs?: any[];
+    /**
+     * Translation arguments for the message of this notification.
+     */
+    readonly msgArgs?: any[];
+    /*
+     * Duration in milliseconds before the toast fades.
+     */
+    readonly duration?: number;
+}
+
+/**
+ * Provides access to display notifications (toasts) in the UI.
+ */
+export interface NotificationContext {
+    /**
+     * Displays an informational toast notification.
+     */
+    info(message: string, options?: NotificationOptions): void;
+    /**
+     * Displays a success toast notification.
+     */
+    success(message: string, options?: NotificationOptions): void;
+    /**
+     * Displays a warning toast notification.
+     */
+    warning(message: string, options?: NotificationOptions): void;
+    /**
+     * Displays an error toast notification.
+     */
+    error(message: string, options?: NotificationOptions): void;
+}
+
+/**
  * The context in which a script is executed, providing access to the editor, disassembler, and workspace contexts,
  * as well as event handling capabilities.
  */
@@ -656,6 +701,10 @@ export interface ScriptContext {
      * The internationalization context, which allows translating strings based on the user's locale and registering new translations.
      */
     readonly i18n: I18NContext;
+    /**
+     * The notification context, which allows displaying toast notifications in the UI.
+     */
+    readonly notification: NotificationContext;
 
     /**
      * Adds an event listener for the specified event type.

--- a/src/lib/script.ts
+++ b/src/lib/script.ts
@@ -47,6 +47,8 @@ import type {
     EventType,
     I18NContext,
     MappingContext,
+    NotificationContext,
+    NotificationOptions,
     Script,
     ScriptContext,
     Disassembler as ScriptDisassembler,
@@ -377,6 +379,41 @@ const i18nCtx: I18NContext = {
     },
 };
 
+const notificationCtx: NotificationContext = {
+    info(message: string, options?: NotificationOptions): void {
+        toast.info(tl(message, ...(options?.msgArgs ?? [])), {
+            duration: options?.duration,
+            description: options?.description
+                ? tl(options.description, ...(options?.descriptionArgs ?? []))
+                : undefined,
+        });
+    },
+    success(message: string, options?: NotificationOptions): void {
+        toast.success(tl(message, ...(options?.msgArgs ?? [])), {
+            duration: options?.duration,
+            description: options?.description
+                ? tl(options.description, ...(options?.descriptionArgs ?? []))
+                : undefined,
+        });
+    },
+    warning(message: string, options?: NotificationOptions): void {
+        toast.warning(tl(message, ...(options?.msgArgs ?? [])), {
+            duration: options?.duration,
+            description: options?.description
+                ? tl(options.description, ...(options?.descriptionArgs ?? []))
+                : undefined,
+        });
+    },
+    error(message: string, options?: NotificationOptions): void {
+        toast.error(tl(message, ...(options?.msgArgs ?? [])), {
+            duration: options?.duration,
+            description: options?.description
+                ? tl(options.description, ...(options?.descriptionArgs ?? []))
+                : undefined,
+        });
+    },
+};
+
 const createContext = (script: Script, parent: ScriptContext | null): ScriptContext => {
     const scriptListeners = new Map<EventType, EventListener<any>[]>();
     const context: Partial<ScriptContext> = {
@@ -386,6 +423,7 @@ const createContext = (script: Script, parent: ScriptContext | null): ScriptCont
         workspace: workspaceCtx,
         mapping: mappingCtx,
         i18n: i18nCtx,
+        notification: notificationCtx,
         addEventListener<K extends EventType>(type: K, listener: EventListener<EventMap[K]>) {
             let listeners = scriptListeners.get(type);
             if (!listeners) {


### PR DESCRIPTION
I don't like the repetition in the impl of the notification context however I didn't like whatever else I came up with either so I left it as is, alternative was:
```ts
const resolve = (key: string, args?: any[]) => tl(key, ...(args ?? []));

const notificationCtx: NotificationContext = (["info", "success", "warning", "error"] as const).reduce(
    (ctx, level) => {
        ctx[level] = (message: string, options?: NotificationOptions) => {
            toast[level](resolve(message, options?.msgArgs), {
                ...options,
                description: options?.description
                    ? resolve(options.description, options.descriptionArgs)
                    : undefined,
            });
        };
        return ctx;
    },
    {} as NotificationContext
);
```