### PR TITLE
feat(script): notification leftovers

### DIFF
--- a/script/index.d.ts
+++ b/script/index.d.ts
@@ -643,6 +643,10 @@ export interface NotificationOptions {
      * Duration in milliseconds before the toast fades.
      */
     readonly duration?: number;
+    /**
+     * The ID of an existing toast to update.
+     */
+    readonly id?: string | number;
 }
 
 /**
@@ -652,19 +656,27 @@ export interface NotificationContext {
     /**
      * Displays an informational toast notification.
      */
-    info(message: string, options?: NotificationOptions): void;
+    info(message: string, options?: NotificationOptions): string | number;
     /**
      * Displays a success toast notification.
      */
-    success(message: string, options?: NotificationOptions): void;
+    success(message: string, options?: NotificationOptions): string | number;
     /**
      * Displays a warning toast notification.
      */
-    warning(message: string, options?: NotificationOptions): void;
+    warning(message: string, options?: NotificationOptions): string | number;
     /**
      * Displays an error toast notification.
      */
-    error(message: string, options?: NotificationOptions): void;
+    error(message: string, options?: NotificationOptions): string | number;
+    /**
+     * Displays a loading toast notification.
+     */
+    loading(message: string, options?: NotificationOptions): string | number;
+    /**
+     * Dismisses a toast notification by its ID, or dismisses all if no ID is provided.
+     */
+    dismiss(id?: string | number): void;
 }
 
 /**

--- a/src/lib/script.ts
+++ b/src/lib/script.ts
@@ -380,37 +380,53 @@ const i18nCtx: I18NContext = {
 };
 
 const notificationCtx: NotificationContext = {
-    info(message: string, options?: NotificationOptions): void {
-        toast.info(tl(message, ...(options?.msgArgs ?? [])), {
+    info(message: string, options?: NotificationOptions): string | number {
+        return toast.info(tl(message, ...(options?.msgArgs ?? [])), {
+            id: options?.id,
             duration: options?.duration,
             description: options?.description
                 ? tl(options.description, ...(options?.descriptionArgs ?? []))
                 : undefined,
         });
     },
-    success(message: string, options?: NotificationOptions): void {
-        toast.success(tl(message, ...(options?.msgArgs ?? [])), {
+    success(message: string, options?: NotificationOptions): string | number {
+        return toast.success(tl(message, ...(options?.msgArgs ?? [])), {
+            id: options?.id,
             duration: options?.duration,
             description: options?.description
                 ? tl(options.description, ...(options?.descriptionArgs ?? []))
                 : undefined,
         });
     },
-    warning(message: string, options?: NotificationOptions): void {
-        toast.warning(tl(message, ...(options?.msgArgs ?? [])), {
+    warning(message: string, options?: NotificationOptions): string | number {
+        return toast.warning(tl(message, ...(options?.msgArgs ?? [])), {
+            id: options?.id,
             duration: options?.duration,
             description: options?.description
                 ? tl(options.description, ...(options?.descriptionArgs ?? []))
                 : undefined,
         });
     },
-    error(message: string, options?: NotificationOptions): void {
-        toast.error(tl(message, ...(options?.msgArgs ?? [])), {
+    error(message: string, options?: NotificationOptions): string | number {
+        return toast.error(tl(message, ...(options?.msgArgs ?? [])), {
+            id: options?.id,
             duration: options?.duration,
             description: options?.description
                 ? tl(options.description, ...(options?.descriptionArgs ?? []))
                 : undefined,
         });
+    },
+    loading(message: string, options?: NotificationOptions): string | number {
+        return toast.loading(tl(message, ...(options?.msgArgs ?? [])), {
+            id: options?.id,
+            duration: options?.duration,
+            description: options?.description
+                ? tl(options.description, ...(options?.descriptionArgs ?? []))
+                : undefined,
+        });
+    },
+    dismiss(id?: string | number): void {
+        toast.dismiss(id);
     },
 };
 


### PR DESCRIPTION
Expose loading toast notification I had forgotten last time, also add functions for toast dismissal.

Pair PR: https://github.com/katana-project/docs/pull/5